### PR TITLE
use primitives for useEffect hook

### DIFF
--- a/components/header/header.js
+++ b/components/header/header.js
@@ -6,9 +6,9 @@ import React from 'react';
 
 const Header = ({ color }) => {
   const global = React.useContext(GlobalContext);
-
+  const { asPath } = router;
   React.useEffect(() => {
-    if (router.asPath == '/search') {
+    if (asPath == '/search') {
       document
         .querySelector('.header__search')
         .classList.add('header__search--hide');


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
here we only need a primitive value asPath and the entire object is passed. And comparing the dependencies will always trigger a re-run. This ends up causing effects to run unnecessarily.
…

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
…

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Browsers:** …
