### PR TITLE
replaced empty-strings by null for conditional classname

### DIFF
--- a/components/navigation/navigation.js
+++ b/components/navigation/navigation.js
@@ -9,7 +9,7 @@ const Navigation = ({ back, forward, isHindi = false }) => (
         {back != undefined && (
           <div
             className={`navigation__back ${
-              forward == undefined ? 'navigation__back--only' : ''
+              forward == undefined ? 'navigation__back--only' : null
             }`}
           >
             <Link href={isHindi ? `/hn/${back.slug}` : `/${back.slug}`}>
@@ -37,7 +37,7 @@ const Navigation = ({ back, forward, isHindi = false }) => (
         {forward != undefined && (
           <div
             className={`navigation__next ${
-              back == undefined ? 'navigation__next--only' : ''
+              back == undefined ? 'navigation__next--only' : null
             }`}
           >
             <Link href={isHindi ? `/hn/${forward.slug}` : `/${forward.slug}`}>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Before it will render ( div class ) and now it will render ( div ). This difference is especially when writing CSS selectors for elements with/without any classes.
…

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
…

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** …

**Browsers:** …
